### PR TITLE
Correction to categorize_primary_race

### DIFF
--- a/R/categorize_primary_race.R
+++ b/R/categorize_primary_race.R
@@ -10,8 +10,8 @@ categorize_primary_race <- function(
     mutate(
       `Primary Race` =
         `Primary Race` |>
-        forcats::fct_recode("White" = "Caucasian") |>
+        forcats::fct_recode("Caucasian" = "White") |>
         forcats::fct_other(drop = other_races) |>
-        forcats::fct_relevel("White", "Black or African American", "Asian", "Other")
+        forcats::fct_relevel("Caucasian", "Black or African American", "Asian", "Other")
     )
 }


### PR DESCRIPTION
corrected error in `forcats::fct_recode` from old = new label to new = old label. updated `forcats:fct_relevel` to use the new label for Caucasian