### PR TITLE
update`fix_tremor_onsets()`; add test.

### DIFF
--- a/R/fix_tremor_onsets.R
+++ b/R/fix_tremor_onsets.R
@@ -7,7 +7,7 @@ fix_tremor_onsets = function(dataset)
       # after discussion with Kyoungmi and Matt, 2023/08/01:
         if_else(
           (`Tremor: Age of onset` == 0) &
-            (`Any tremor (excluding Head Tremor)` == "No Tremors Recorded"),
+            (`Any tremor (excluding Head Tremor)` == "No tremors recorded"),
           NA_real_,
           `Tremor: Age of onset`
         )

--- a/tests/testthat/test-tremor-onset.R
+++ b/tests/testthat/test-tremor-onset.R
@@ -1,0 +1,17 @@
+test_that(
+  "`Tremor: Age of onset: missingness reasons` matches `Tremor: Age of onset`",
+
+  {
+  inconsistent =
+    gp34 |>
+    filter(
+      is.na(`Tremor: Age of onset`),
+      `Tremor: Age of onset: missingness reasons` == "[Valid data recorded]") |>
+    select(
+      `Tremor: Age of onset`,
+      `Tremor: Age of onset: missingness reasons`)
+
+  expect_equal(object = nrow(inconsistent), expected = 0)
+
+
+})


### PR DESCRIPTION
I noticed that `fix_tremor_onsets()` was using a different capitalization of "No tremors recorded" than `create_any_tremor()`. I corrected `fix_tremor_onsets()` to match `create_any_tremor()`, and added a new test in `tests/testthat/test-tremor-onset.R`.

Running that test (with `devtools::test()`) produces:

```
nrow(inconsistent) (`actual`) not equal to 0 (`expected`).

  `actual`: 2
`expected`: 0
```

The observations in `inconsistent` are:

```
# A tibble: 2 × 2
  `Tremor: Age of onset` `Tremor: Age of onset: missingness reasons`
                   <dbl> <fct>                                      
1                     NA [Valid data recorded]                      
2                     NA [Valid data recorded]                      
```

Would moving `fix_onset_age_vars()` after `fix_tremor_onsets()` resolve this? Not sure if it would create other problems. 
