### PR TITLE
de-duplicate missingness reasons

### DIFF
--- a/R/fix_factors.R
+++ b/R/fix_factors.R
@@ -5,7 +5,7 @@ fix_factors = function(dataset)
       across(
         where(is.factor) &
           !contains(": missingness reasons") &
-          !contains("FX**"),
+          !ends_with("*"),
 
         list(
           tmp = replace_missing_codes_with_NAs,


### PR DESCRIPTION
variables that came from categorizing numerical variables shouldn't need NA removal, and we don't need to create "missingness reasons", since that variable should already exist for the numerical version.