### PR TITLE
Fix table margins

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fxtas
 Title: FXTAS
-Version: 0.0.0.9050
+Version: 0.0.0.9051
 Authors@R: c(
     person("Douglas Ezra", "Morrison", , "demorrison@ucdavis.edu", role = c("cre", "aut")),
     person("Matthew", "Ponzini", , "mdponzini@ucdavis.edu", role = c("aut")))

--- a/inst/analyses/exploration.qmd
+++ b/inst/analyses/exploration.qmd
@@ -301,7 +301,7 @@ table1(
   table1::t1flex() |>
   shared_flextable_settings() |> 
   flextable::width(width = width1) |> 
-  flextable::width(j = 1, width = 1.545) |> 
+  flextable::width(j = 1, width = 1.4) |> 
   flextable::width(j = c(2, 5), width = 0.75) |> 
   flextable::width(j = c(3, 6), width = 0.8) |> 
   flextable::width(j = c(4, 7), width = 0.85)
@@ -363,7 +363,7 @@ table1(
   table1::t1flex() |>
   shared_flextable_settings() |> 
   flextable::width(width = width1) |> 
-  flextable::width(j = 1, width = 1.45) |> 
+  flextable::width(j = 1, width = 1.35) |> 
   flextable::width(j = c(2, 5), width = 0.75) |> 
   flextable::width(j = c(3, 6), width = 0.8) |> 
   flextable::width(j = c(4, 7), width = 0.85)
@@ -477,7 +477,7 @@ table1(
   table1::t1flex() |>
   shared_flextable_settings() |>
   flextable::width(width = width1) |>
-  flextable::width(j = 1, width = 1.4) |> 
+  flextable::width(j = 1, width = 1.3) |> 
   flextable::width(j = c(2, 5), width = 0.8) |> 
   flextable::width(j = c(3, 6), width = 0.8) |> 
   flextable::width(j = c(4, 7), width = 0.85)

--- a/inst/analyses/packages.csv
+++ b/inst/analyses/packages.csv
@@ -150,7 +150,7 @@ futile.options,1.0.1,CRAN (R 4.5.0)
 future,1.67.0,CRAN (R 4.5.0)
 future.apply,1.20.0,CRAN (R 4.5.0)
 fuzzyjoin,0.1.6.1,CRAN (R 4.5.0)
-fxtas,0.0.0.9050,load_all()
+fxtas,0.0.0.9027,local
 gargle,1.6.0,CRAN (R 4.5.0)
 gbutils,0.5,CRAN (R 4.5.0)
 gdtools,0.4.4,CRAN (R 4.5.0)


### PR DESCRIPTION
This pull request makes minor adjustments to table column widths in `inst/analyses/exploration.qmd` for improved formatting, updates the package version in the `DESCRIPTION` file, and modifies the package source and version in `inst/analyses/packages.csv`.

Formatting improvements in tables:

* Reduced the width of the first column in three separate `table1` outputs within `inst/analyses/exploration.qmd` for better visual alignment. [[1]](diffhunk://#diff-b7ae311f1c5691ff3f27686b82436945c9c0c32b81c3aee129b1639e9a3a9be6L304-R304) [[2]](diffhunk://#diff-b7ae311f1c5691ff3f27686b82436945c9c0c32b81c3aee129b1639e9a3a9be6L366-R366) [[3]](diffhunk://#diff-b7ae311f1c5691ff3f27686b82436945c9c0c32b81c3aee129b1639e9a3a9be6L480-R480)
