### PR TITLE
Add cleanup-pr-previews with gh-pages history compaction (closes #155)

### DIFF
--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -1,0 +1,28 @@
+# Housekeeping half of the PR-preview family, delegated to the reusable
+# cleanup-pr-previews workflow in d-morrison/gha. Periodically deletes gh-pages
+# preview directories for PRs that are no longer open, and (compact-history)
+# orphan-squashes gh-pages to a single commit so the deleted snapshots stop
+# bloating the repo. The calling job grants contents: write so the reusable can
+# commit the deletions / force-push the compacted branch back to gh-pages.
+name: Clean up PR Previews
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday at midnight UTC
+
+# Only one cleanup at a time: a manual dispatch overlapping the scheduled run
+# would otherwise race on gh-pages. The reusable's --force-with-lease keeps that
+# data-safe, but serializing avoids the wasted runner and noisy retries.
+concurrency:
+  group: gh-pages-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    permissions:
+      contents: write
+      pull-requests: read
+    uses: d-morrison/gha/.github/workflows/cleanup-pr-previews.yml@v2
+    with:
+      compact-history: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fxtas
 Title: FXTAS
-Version: 0.0.0.9052
+Version: 0.0.0.9053
 Authors@R: c(
     person("Douglas Ezra", "Morrison", , "demorrison@ucdavis.edu", role = c("cre", "aut")),
     person("Matthew", "Ponzini", , "mdponzini@ucdavis.edu", role = c("aut")))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fxtas
 Title: FXTAS
-Version: 0.0.0.9053
+Version: 0.0.0.9054
 Authors@R: c(
     person("Douglas Ezra", "Morrison", , "demorrison@ucdavis.edu", role = c("cre", "aut")),
     person("Matthew", "Ponzini", , "mdponzini@ucdavis.edu", role = c("aut")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # fxtas (development version)
 
+## Internal
+
+* Added a scheduled `Clean up PR Previews` workflow that prunes closed-PR `gh-pages` previews and compacts `gh-pages` history, so deleted render snapshots stop bloating the repo (closes #155).
+
 ## Manuscript
 
 * Moved manuscript to `analyses/` (#69)


### PR DESCRIPTION
Adopts the `cleanup-pr-previews` reusable (d-morrison/gha#136) with `compact-history: true`: prune closed-PR previews and orphan-squash `gh-pages` to one commit, so ~1073 deleted snapshots stop bloating the repo (~780 MB `.git`). Branch-based Pages, previews preserved, `--force-with-lease`. Same fix as ucdavis/epi204#352. After merge, one `workflow_dispatch` reclaims the existing history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)