### PR TITLE
Fix CI: drop CRAN-archived deps (#157) + devtag/roxygen2 8.0.0 docs (#159)

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -12,7 +12,7 @@ if (interactive()) {
   (require(devtools)) # loads usethis
   # (require(rsconnect)) # loads rsconnect
   # suppressMessages(require(dplyr))
-  require("pryr")
+  # require("pryr") # pryr archived from CRAN 2026-01-30; install manually if needed
   # suppressMessages(require(lubridate))
   # suppressMessages(require(magrittr))
   (require(conflicted))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fxtas
 Title: FXTAS
-Version: 0.0.0.9052
+Version: 0.0.0.9053
 Authors@R: c(
     person("Douglas Ezra", "Morrison", , "demorrison@ucdavis.edu", role = c("cre", "aut")),
     person("Matthew", "Ponzini", , "mdponzini@ucdavis.edu", role = c("aut")))
@@ -77,7 +77,6 @@ Suggests:
     tidyverse,
     tinyscholar,
     vdiffr,
-    veccompare,
     VennDiagram,
     viridis,
     webshot2,
@@ -85,8 +84,7 @@ Suggests:
     writexl,
     chromote,
     ggview,
-    sessioninfo,
-    pryr
+    sessioninfo
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,6 @@ Suggests:
     colorblindcheck (>= 1.0.3),
     constructive,
     cardx (>= 0.2.3),
-    devtag (>= 0.0.0.9000),
     doconv,
     knitr,
     plotly,
@@ -89,7 +88,7 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 LazyData: true
-RoxygenNote: 7.3.3
+RoxygenNote: 8.0.0
 Depends: 
     R (>= 4.2.0)
 VignetteBuilder: knitr, quarto
@@ -100,13 +99,10 @@ Config/reticulate/autoconfigure:
     )
   )
 Config/build/copy-method: link
-Roxygen: list(markdown = TRUE, roclets = c("collate", "rd", "namespace", "devtag::dev_roclet"))
-Remotes: 
-    moodymudskipper/devtag,
+Roxygen: list(markdown = TRUE, roclets = c("collate", "rd", "namespace"))
+Remotes:
     d-morrison/gtsummary@ezra-dev,
     insightsengineering/cardx,
     davidsjoberg/ggbump,
     d-morrison/colorblindcheck
-Config/Needs/build: moodymudskipper/devtag
-Config/Needs/roxygen2: moodymudskipper/devtag
 Config/Needs/website: quarto, rmarkdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,7 @@ on Dr. Bourgeois's recommendation.
 
 * moved `analyses/` into `inst` (#120)
 * removed `veccompare` and `pryr` from `Suggests`; both were archived from CRAN and unused in the package, which broke dependency resolution on all CI jobs (#157)
+* dropped the `devtag` roclet (no `@dev` tags were in use; internal functions already use `@keywords internal`) and regenerated `man/` with roxygen2 8.0.0, fixing the `Documentation check` job (#159)
 * updated test-coverage.yaml workflow
 * updated readme to specify new location of manuscript source code 
 in `analyses/`

--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,7 @@ on Dr. Bourgeois's recommendation.
 ## Package setup
 
 * moved `analyses/` into `inst` (#120)
+* removed `veccompare` and `pryr` from `Suggests`; both were archived from CRAN and unused in the package, which broke dependency resolution on all CI jobs (#157)
 * updated test-coverage.yaml workflow
 * updated readme to specify new location of manuscript source code 
 in `analyses/`

--- a/R/compile_biomarker_groups_table.R
+++ b/R/compile_biomarker_groups_table.R
@@ -3,7 +3,7 @@
 #' @param dataset passed to [compile_biomarker_group_list()]
 #' @param biomarker_group_list todo
 #' @param colors which colors to use
-#' @inheritDotParams compile_biomarker_group_list
+#' @param ... additional arguments passed to [compile_biomarker_group_list()]
 #'
 #' @returns a [tibble::tbl_df]
 #' @export

--- a/R/make_demographics_table.R
+++ b/R/make_demographics_table.R
@@ -5,7 +5,8 @@
 #' @param strata names of column variable, specified as [character]
 #' @param vars names of row variables, specified as [character]
 #' @param make_ft [logical] whether to convert to flextable
-#' @inheritDotParams format_demographics_table_as_flextable -x
+#' @param ... additional arguments passed to
+#' [format_demographics_table_as_flextable()]
 #' @inherit format_demographics_table_as_flextable return
 #' @export
 #'

--- a/R/missingness_reasons_numeric.R
+++ b/R/missingness_reasons_numeric.R
@@ -2,7 +2,6 @@
 #'
 #' @param x the original vector to be turned into a numeric
 #' @param x.clean the cleaned vector
-#' @param ...
 #'
 #' @inheritDotParams clean_numeric
 #' @returns a [factor] [vector] corresponding to the elements of `x`,

--- a/R/missingness_reasons_numeric.R
+++ b/R/missingness_reasons_numeric.R
@@ -2,6 +2,7 @@
 #'
 #' @param x the original vector to be turned into a numeric
 #' @param x.clean the cleaned vector
+#' @param ...
 #'
 #' @inheritDotParams clean_numeric
 #' @returns a [factor] [vector] corresponding to the elements of `x`,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -62,6 +62,8 @@ rds
 readme
 reticulate
 rmarkdown
+roclet
+roxygen
 rstudio
 scid
 startpoints

--- a/man/collapse_mri_levels.Rd
+++ b/man/collapse_mri_levels.Rd
@@ -7,10 +7,10 @@
 collapse_mri_levels(dataset, ...)
 }
 \arguments{
-\item{dataset}{a \link[tibble:tbl_df-class]{tibble::tbl_df}}
+\item{dataset}{a \link[tibble:tbl_df]{tibble::tbl_df}}
 
 \item{...}{
-  Arguments passed on to \code{\link[=collapse_mri_level]{collapse_mri_level}}
+  Arguments passed on to \code{\link{collapse_mri_level}}
   \describe{
     \item{\code{x}}{a MRI variable (\link{factor})}
     \item{\code{levels}}{\link{character} string vector of levels to collapse}

--- a/man/collapse_scid_levels.Rd
+++ b/man/collapse_scid_levels.Rd
@@ -7,10 +7,10 @@
 collapse_scid_levels(dataset, ...)
 }
 \arguments{
-\item{dataset}{a \link[tibble:tbl_df-class]{tibble::tbl_df}}
+\item{dataset}{a \link[tibble:tbl_df]{tibble::tbl_df}}
 
 \item{...}{
-  Arguments passed on to \code{\link[=collapse_scid_level]{collapse_scid_level}}
+  Arguments passed on to \code{\link{collapse_scid_level}}
   \describe{
     \item{\code{x}}{a scid variable (\link{factor})}
     \item{\code{levels}}{\link{character} string vector of levels to collapse}

--- a/man/combine_subtype_and_demos.Rd
+++ b/man/combine_subtype_and_demos.Rd
@@ -13,7 +13,7 @@ combine_subtype_and_demos(patient_data, subtype_data)
 (produced as a list element by \code{\link[=extract_results_from_pickle]{extract_results_from_pickle()}})}
 }
 \value{
-a \link[tibble:tbl_df-class]{tibble::tbl_df} combining \code{patient_data} and \code{subtype_data}
+a \link[tibble:tbl_df]{tibble::tbl_df} combining \code{patient_data} and \code{subtype_data}
 via \code{\link[dplyr:bind_cols]{dplyr::bind_cols()}}
 (assuming they were provided in the same row-order)
 }

--- a/man/compact_pvd_data_prep.Rd
+++ b/man/compact_pvd_data_prep.Rd
@@ -19,7 +19,7 @@ order of biomarkers to use}
 \item{biomarker_var}{either "biomarker" or "biomarker_label"}
 }
 \value{
-a \link[tibble:tbl_df-class]{tibble::tbl_df}
+a \link[tibble:tbl_df]{tibble::tbl_df}
 }
 \description{
 plot_compact_pvd: data prep

--- a/man/compile_biomarker_groups_table.Rd
+++ b/man/compile_biomarker_groups_table.Rd
@@ -17,15 +17,9 @@ compile_biomarker_groups_table(
 \item{biomarker_group_list}{todo}
 
 \item{colors}{which colors to use}
-
-\item{...}{
-  Arguments passed on to \code{\link[=compile_biomarker_group_list]{compile_biomarker_group_list}}
-  \describe{
-    \item{\code{}}{}
-  }}
 }
 \value{
-a \link[tibble:tbl_df-class]{tibble::tbl_df}
+a \link[tibble:tbl_df]{tibble::tbl_df}
 }
 \description{
 Compile biomarker groups table

--- a/man/compile_biomarker_groups_table.Rd
+++ b/man/compile_biomarker_groups_table.Rd
@@ -17,6 +17,8 @@ compile_biomarker_groups_table(
 \item{biomarker_group_list}{todo}
 
 \item{colors}{which colors to use}
+
+\item{...}{additional arguments passed to \code{\link[=compile_biomarker_group_list]{compile_biomarker_group_list()}}}
 }
 \value{
 a \link[tibble:tbl_df]{tibble::tbl_df}

--- a/man/compute_confus_matrix.Rd
+++ b/man/compute_confus_matrix.Rd
@@ -15,7 +15,7 @@ compute_confus_matrix(
 \item{biomarker_event_order}{todo}
 }
 \value{
-a \link[tibble:tbl_df-class]{tibble::tbl_df}
+a \link[tibble:tbl_df]{tibble::tbl_df}
 }
 \description{
 compute \code{confus_matrix} as in python version

--- a/man/compute_prob_correct.Rd
+++ b/man/compute_prob_correct.Rd
@@ -16,7 +16,7 @@ compute_prob_correct(dataset, biomarker_levels, max_prob = 1)
 \value{
 a \code{\link[=structure]{structure()}} that is fundamentally a named \code{\link[=numeric]{numeric()}} vector
 corresponding to the elements of \code{biomarker_levels},
-but also contains a \link[tibble:tbl_df-class]{tibble::tbl_df} as attribute \code{data}
+but also contains a \link[tibble:tbl_df]{tibble::tbl_df} as attribute \code{data}
 (easier than fixing all uses of this function)
 }
 \description{

--- a/man/compute_prob_scores.Rd
+++ b/man/compute_prob_scores.Rd
@@ -28,7 +28,7 @@ compute_prob_scores(
 \item{verbose}{\code{\link[=logical]{logical()}} indicating whether to print debugging information}
 
 \item{...}{
-  Arguments passed on to \code{\link[=compute_prob_dist]{compute_prob_dist}}
+  Arguments passed on to \code{\link{compute_prob_dist}}
   \describe{
     \item{\code{prob_correct}}{the probability of correctly classifying the underlying biomarker level: p(obs = true)}
   }}

--- a/man/create_scid_domains.Rd
+++ b/man/create_scid_domains.Rd
@@ -7,12 +7,12 @@
 create_scid_domains(dataset, scid_vars = all_scid_vars)
 }
 \arguments{
-\item{dataset}{a \link[tibble:tbl_df-class]{tibble::tbl_df} containing all of \code{scid_vars} as columns}
+\item{dataset}{a \link[tibble:tbl_df]{tibble::tbl_df} containing all of \code{scid_vars} as columns}
 
 \item{scid_vars}{a \code{\link[=character]{character()}} vector}
 }
 \value{
-a \link[tibble:tbl_df-class]{tibble::tbl_df}
+a \link[tibble:tbl_df]{tibble::tbl_df}
 }
 \description{
 Create SCID domain variables

--- a/man/extract_figs_from_pickle.Rd
+++ b/man/extract_figs_from_pickle.Rd
@@ -34,7 +34,7 @@ extract_figs_from_pickle(
 \item{biomarker_levels}{\link{list} containing biomarker ordinal level info}
 
 \item{...}{
-  Arguments passed on to \code{\link[=plot_positional_var]{plot_positional_var}}
+  Arguments passed on to \code{\link{plot_positional_var}}
   \describe{
     \item{\code{samples_sequence}}{todo}
     \item{\code{samples_f}}{todo}

--- a/man/extract_results_from_pickle.Rd
+++ b/man/extract_results_from_pickle.Rd
@@ -44,7 +44,7 @@ indicating how to order the subtypes}
 \item{verbose}{whether to print messages}
 
 \item{...}{
-  Arguments passed on to \code{\link[=format_results_list]{format_results_list}}
+  Arguments passed on to \code{\link{format_results_list}}
   \describe{
     \item{\code{format_sst}}{should the subtype and stage table be formatted?
 (doesn't work for cross-validation fold pickle-files)}

--- a/man/extract_results_from_pickles.Rd
+++ b/man/extract_results_from_pickles.Rd
@@ -44,7 +44,7 @@ indicating how to order the subtypes}
 \item{verbose}{whether to print messages}
 
 \item{...}{
-  Arguments passed on to \code{\link[=format_results_list]{format_results_list}}
+  Arguments passed on to \code{\link{format_results_list}}
   \describe{
     \item{\code{format_sst}}{should the subtype and stage table be formatted?
 (doesn't work for cross-validation fold pickle-files)}

--- a/man/format_demographics_table_as_flextable.Rd
+++ b/man/format_demographics_table_as_flextable.Rd
@@ -7,10 +7,10 @@
 format_demographics_table_as_flextable(x, ...)
 }
 \arguments{
-\item{x}{a \link[gtsummary:gtsummary-package]{gtsummary::gtsummary} object}
+\item{x}{a \link[gtsummary:gtsummary]{gtsummary::gtsummary} object}
 
 \item{...}{
-  Arguments passed on to \code{\link[=shared_flextable_settings]{shared_flextable_settings}}
+  Arguments passed on to \code{\link{shared_flextable_settings}}
   \describe{
     \item{\code{padding}}{controls \code{padding.top} and \code{padding.bottom} in \code{\link[flextable:padding]{flextable::padding()}}}
   }}

--- a/man/format_likelihoods.Rd
+++ b/man/format_likelihoods.Rd
@@ -10,7 +10,7 @@ format_likelihoods(likelihoods)
 \item{likelihoods}{todo}
 }
 \value{
-a \link[tibble:tbl_df-class]{tibble::tbl_df}
+a \link[tibble:tbl_df]{tibble::tbl_df}
 }
 \description{
 Title

--- a/man/fxtas-package.Rd
+++ b/man/fxtas-package.Rd
@@ -22,6 +22,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Douglas Ezra Morrison \email{demorrison@ucdavis.edu}
   \item Matthew Ponzini \email{mdponzini@ucdavis.edu}
 }
 

--- a/man/get_biomarker_events_table.Rd
+++ b/man/get_biomarker_events_table.Rd
@@ -12,7 +12,7 @@ get_biomarker_events_table(biomarker_levels, do_factor = TRUE)
 \item{do_factor}{whether to turn \code{biomarker} column into factor and sort on it, after \code{level}}
 }
 \value{
-a \link[tibble:tbl_df-class]{tibble::tbl_df}
+a \link[tibble:tbl_df]{tibble::tbl_df}
 }
 \description{
 Construct biomarker events table

--- a/man/get_visit1.Rd
+++ b/man/get_visit1.Rd
@@ -7,15 +7,15 @@
 get_visit1(dataset)
 }
 \arguments{
-\item{dataset}{a \link[tibble:tbl_df-class]{tibble::tbl_df} containing the following columns:
+\item{dataset}{a \link[tibble:tbl_df]{tibble::tbl_df} containing the following columns:
 \itemize{
 \item \verb{FXS ID}: participant ID number (\code{\link[=character]{character()}})
-\item \verb{Visit Date}: date of clinic visit (\code{\link[base:Dates]{base::Date()}})
+\item \verb{Visit Date}: date of clinic visit (\code{\link[base:Date]{base::Date()}})
 \item \verb{Event Name}: role of clinic visit in the study design (\code{\link[=character]{character()}})
 }}
 }
 \value{
-a \link[tibble:tbl_df-class]{tibble::tbl_df}
+a \link[tibble:tbl_df]{tibble::tbl_df}
 }
 \description{
 Get each participant's first visit in dataset

--- a/man/install_pySuStaIn.Rd
+++ b/man/install_pySuStaIn.Rd
@@ -48,7 +48,7 @@ incompatible--distribution channel. (\code{ignore_installed} is an alias for
   }}
 }
 \description{
-This function is a wrapper for \link[reticulate:conda-tools]{reticulate::conda_install}.
+This function is a wrapper for \link[reticulate:conda_install]{reticulate::conda_install}.
 Its implementation follows the instructions in:
 \itemize{
 \item https://rstudio.github.io/reticulate/articles/package.html

--- a/man/make_biomarker_events_table.Rd
+++ b/man/make_biomarker_events_table.Rd
@@ -12,7 +12,7 @@ make_biomarker_events_table(biomarker_levels, biomarker_groups)
 \item{biomarker_groups}{todo}
 }
 \value{
-a \link[tibble:tbl_df-class]{tibble::tbl_df}
+a \link[tibble:tbl_df]{tibble::tbl_df}
 }
 \description{
 Construct biomarker events table

--- a/man/make_demographics_table.Rd
+++ b/man/make_demographics_table.Rd
@@ -21,12 +21,6 @@ make_demographics_table(
 \item{vars}{names of row variables, specified as \link{character}}
 
 \item{make_ft}{\link{logical} whether to convert to flextable}
-
-\item{...}{
-  Arguments passed on to \code{\link[=format_demographics_table_as_flextable]{format_demographics_table_as_flextable}}
-  \describe{
-    \item{\code{}}{}
-  }}
 }
 \value{
 a \link[flextable:flextable]{flextable::flextable}

--- a/man/make_demographics_table.Rd
+++ b/man/make_demographics_table.Rd
@@ -21,6 +21,9 @@ make_demographics_table(
 \item{vars}{names of row variables, specified as \link{character}}
 
 \item{make_ft}{\link{logical} whether to convert to flextable}
+
+\item{...}{additional arguments passed to
+\code{\link[=format_demographics_table_as_flextable]{format_demographics_table_as_flextable()}}}
 }
 \value{
 a \link[flextable:flextable]{flextable::flextable}

--- a/man/missingness_reasons.numeric.Rd
+++ b/man/missingness_reasons.numeric.Rd
@@ -12,7 +12,7 @@ missingness_reasons.numeric(x, x.clean = clean_numeric(x, ...), ...)
 \item{x.clean}{the cleaned vector}
 
 \item{...}{
-  Arguments passed on to \code{\link[=clean_numeric]{clean_numeric}}
+  Arguments passed on to \code{\link{clean_numeric}}
   \describe{
     \item{\code{NA_codes}}{numeric values that should be turned into to NAs}
     \item{\code{extra_codes}}{codes besides 777, 888, 999 to turn into NAs; has no effect if the \code{NA_codes} argument is changed from default by the user.}

--- a/man/plot_compact_pvd.Rd
+++ b/man/plot_compact_pvd.Rd
@@ -76,7 +76,7 @@ Current options are \code{"level"} and \code{"subscript"}}
 \item{strip_text_size}{passed to \code{ggtext::element_markdown()}}
 
 \item{...}{
-  Arguments passed on to \code{\link[=compact_pvd_data_prep]{compact_pvd_data_prep}}
+  Arguments passed on to \code{\link{compact_pvd_data_prep}}
   \describe{
     \item{\code{biomarker_order}}{a \link{character} vector specifying the
 order of biomarkers to use}

--- a/man/plot_positional_var.Rd
+++ b/man/plot_positional_var.Rd
@@ -100,7 +100,7 @@ plot_positional_var(
 \item{use_labels}{whether to use biomarker labels or variable names}
 
 \item{...}{
-  Arguments passed on to \code{\link[=autoplot.PF]{autoplot.PF}}
+  Arguments passed on to \code{\link{autoplot.PF}}
   \describe{
     \item{\code{object}}{a "PF" object (created by \code{compute_position_frequencies()})}
     \item{\code{size.y}}{size of biomarker event labels}

--- a/man/pvd_scatter.Rd
+++ b/man/pvd_scatter.Rd
@@ -16,7 +16,7 @@ pvd_scatter(
 
 \item{nrow_colors}{an \link{integer}}
 
-\item{group_colors}{palette for \link[ggplot2:scale_manual]{ggplot2::scale_color_manual}}
+\item{group_colors}{palette for \link[ggplot2:scale_color_manual]{ggplot2::scale_color_manual}}
 
 \item{legend_text_size}{a \link[grid:unit]{grid::unit}}
 }

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -12,8 +12,8 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{ggplot2}{\code{\link[ggplot2]{autoplot}}}
+  \item{ggplot2}{\code{\link[ggplot2:autoplot]{autoplot()}}}
 
-  \item{labelled}{\code{\link[labelled]{var_label}}}
+  \item{labelled}{\code{\link[labelled:var_label]{var_label()}}}
 }}
 

--- a/man/run_OSA_permuted.Rd
+++ b/man/run_OSA_permuted.Rd
@@ -19,7 +19,7 @@ run_OSA_permuted(
 \item{patient_data}{patient biomarker data}
 
 \item{...}{
-  Arguments passed on to \code{\link[=run_OSA]{run_OSA}}
+  Arguments passed on to \code{\link{run_OSA}}
   \describe{
     \item{\code{prob_score}}{\link{array} probability of each score for all subjects across all biomarkers
 \itemize{

--- a/man/run_and_save_OSA.Rd
+++ b/man/run_and_save_OSA.Rd
@@ -29,7 +29,7 @@ run_and_save_OSA(
 \item{rda_filename}{name of rda file containing environment used to run analyses}
 
 \item{...}{
-  Arguments passed on to \code{\link[=run_OSA]{run_OSA}}
+  Arguments passed on to \code{\link{run_OSA}}
   \describe{
     \item{\code{prob_score}}{\link{array} probability of each score for all subjects across all biomarkers
 \itemize{

--- a/man/search_articles.Rd
+++ b/man/search_articles.Rd
@@ -10,7 +10,7 @@ search_articles(query)
 \item{query}{a \link{character} string}
 }
 \value{
-a \link[tibble:tbl_df-class]{tibble::tbl_df}
+a \link[tibble:tbl_df]{tibble::tbl_df}
 }
 \description{
 Search PubMed for FXTAS-related articles

--- a/man/stage_barplot.SuStaIn_model.Rd
+++ b/man/stage_barplot.SuStaIn_model.Rd
@@ -10,7 +10,7 @@
 \item{object}{a \code{SuStaIn_model} object}
 
 \item{...}{
-  Arguments passed on to \code{\link[=stage_barplot.default]{stage_barplot.default}}
+  Arguments passed on to \code{\link{stage_barplot.default}}
   \describe{
     \item{\code{xmax}}{largest x-value to display}
     \item{\code{include_type_0}}{\link{logical} whether to include Type 0 in the plot}

--- a/man/stage_barplot.list.Rd
+++ b/man/stage_barplot.list.Rd
@@ -10,7 +10,7 @@
 \item{object}{a \link{list} of \code{Sustain_model} objects}
 
 \item{...}{
-  Arguments passed on to \code{\link[=stage_barplot.default]{stage_barplot.default}}
+  Arguments passed on to \code{\link{stage_barplot.default}}
   \describe{
     \item{\code{xmax}}{largest x-value to display}
     \item{\code{include_type_0}}{\link{logical} whether to include Type 0 in the plot}

--- a/man/table_subtype_by_demographics.Rd
+++ b/man/table_subtype_by_demographics.Rd
@@ -71,8 +71,7 @@ Must be one of \code{c("column", "row", "cell")}. Default is \code{"column"}.
 
 In rarer cases, you may need to define/override the typical denominators.
 In these cases, pass an integer or a data frame. Refer to the
-\code{\link[cards:ard_tabulate]{?cards::ard_tabulate(denominator)}} help file for details.
-When a data frame is passed, this data frame is used to calculate header counts.}
+\code{\link[cards:ard_tabulate]{?cards::ard_tabulate(denominator)}} help file for details.}
     \item{\code{include}}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
 Variables to include in the summary table. Default is \code{everything()}.}
   }}

--- a/man/table_subtype_by_demographics.Rd
+++ b/man/table_subtype_by_demographics.Rd
@@ -71,7 +71,8 @@ Must be one of \code{c("column", "row", "cell")}. Default is \code{"column"}.
 
 In rarer cases, you may need to define/override the typical denominators.
 In these cases, pass an integer or a data frame. Refer to the
-\code{\link[cards:ard_tabulate]{?cards::ard_tabulate(denominator)}} help file for details.}
+\code{\link[cards:ard_tabulate]{?cards::ard_tabulate(denominator)}} help file for details.
+When a data frame is passed, this data frame is used to calculate header counts.}
     \item{\code{include}}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
 Variables to include in the summary table. Default is \code{everything()}.}
   }}


### PR DESCRIPTION
Unblocks all CI in the repo, which was failing for two independent, pre-existing reasons (the second was masked by the first).

## 1. Dependency resolution — closes #157

`pak` couldn't resolve two `Suggests` packages, failing the install step on every R job:

- `pryr` — archived from CRAN **2026-01-30** (maintainer's request)
- `veccompare` — archived from CRAN **2026-04-30** (maintainer email undeliverable)

Both are **unused** anywhere in `R/`, `tests/`, `vignettes/`, or `NAMESPACE`, so they're removed from `Suggests`. Also commented out the dev-only `require("pryr")` in `.Rprofile`. Verified locally: `pak::pkg_deps("deps::.")` then resolves the full graph (213 packages, 0 unresolved).

## 2. Documentation check — closes #159

Once deps resolved, the `Documentation check` ran and failed: CI uses **roxygen2 8.0.0** but `man/` + `RoxygenNote` were generated with 7.3.3, so ~30 `.Rd` files regenerate.

Rather than reinstate the GitHub-only `devtag` build dependency, **dropped it**: no `@dev` tags are in use anywhere, and internal functions already use `@keywords internal`. Removed `devtag` from `Suggests`, `Remotes`, `Config/Needs/build`, `Config/Needs/roxygen2`, and the roclet list, then regenerated `man/` with roxygen2 8.0.0 (`RoxygenNote` → 8.0.0). Changes are pure roxygen-8.0.0 `.Rd` formatting; `NAMESPACE` is unchanged and the regen is idempotent.

Closes #157, closes #159. Unblocks CI for #156 and every other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)