### PR TITLE
Repoint gha reusable workflows to Morrison-Lab/gha

### DIFF
--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -1,5 +1,5 @@
 # Housekeeping half of the PR-preview family, delegated to the reusable
-# cleanup-pr-previews workflow in d-morrison/gha. Periodically deletes gh-pages
+# cleanup-pr-previews workflow in Morrison-Lab/gha. Periodically deletes gh-pages
 # preview directories for PRs that are no longer open, and (compact-history)
 # orphan-squashes gh-pages to a single commit so the deleted snapshots stop
 # bloating the repo. The calling job grants contents: write so the reusable can
@@ -23,6 +23,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    uses: d-morrison/gha/.github/workflows/cleanup-pr-previews.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/cleanup-pr-previews.yml@v2
     with:
       compact-history: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fxtas
 Title: FXTAS
-Version: 0.0.0.9054
+Version: 0.0.0.9055
 Authors@R: c(
     person("Douglas Ezra", "Morrison", , "demorrison@ucdavis.edu", role = c("cre", "aut")),
     person("Matthew", "Ponzini", , "mdponzini@ucdavis.edu", role = c("aut")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Internal
 
+* Updated the reusable GitHub Actions workflows to call `Morrison-Lab/gha`
+  instead of `d-morrison/gha`, following that repository's move.
+  Actions does not follow repository-rename redirects for `uses:`, so the
+  calls were failing to resolve before any job started.
 * Added a scheduled `Clean up PR Previews` workflow that prunes closed-PR `gh-pages` previews and compacts `gh-pages` history, so deleted render snapshots stop bloating the repo (closes #155).
 
 ## Manuscript


### PR DESCRIPTION
The `gha` repo moved from `d-morrison/gha` to `Morrison-Lab/gha`.

GitHub Actions does **not** follow repository-rename redirects for `uses:`, so
every call in this repo was failing to resolve before any job started. This
repoints all 2 reference(s) across 1 workflow file(s). Tags and paths
are unchanged.

Direct push to the default branch was blocked by repository rules, so this is a PR.